### PR TITLE
Add Table of Contents and what we own

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # Table of Contents
+
+## Identity
+1. [Team Saturn Principles and Processes](identity/Team-Saturn-Principles-and-Processes.md): This document outlines what our team principles are, what our definitions of done/ready/quality are, our approach to delivering and deploying code, and what our process for handling emergencies is.
+2. [What We Own](identity/What-We-Own.md): This document outlines all the different services that the Saturn team owns
+3. [Who's Who](identity/Whos-Who.md): This document outlines who all is in the team, and what their roles are.
+
+## Tooling
+1. [Vault](tooling/Vault.md): This document outlines our use of Vault for secrets management, and how to run and use vault
+

--- a/identity/What-We-Own.md
+++ b/identity/What-We-Own.md
@@ -8,6 +8,6 @@
 | [Calhoun](https://github.com/DataBiosphere/calhoun) | Calhoun is a service which generates read-only views of notebooks for previews. It does not require a running cluster, and spits out the notebook file as HTML. |
 | [Job Manager](https://github.com/DataBiosphere/job-manager) | Job manager is a UI and API service that is ued by users of the Terra platform to manage and inspect in progress, finished, or errored batch jobs. |
 | [Lyle](https://github.com/DataBiosphere/lyle) | Lyle is a service to manage allocating temporary google service accounts for use as test users |
-| [Rex](https://github.com/DataBiosphere/rex) | Rex is a service for collecting NPS survey responses. |
+| [Rex](https://github.com/DataBiosphere/rex) | Rex is a service for collecting Net Promoter Score (NPS) survey responses. |
 | [Saturn UI Prod Deploy](https://github.com/DataBiosphere/saturn-ui-prod-deploy) | This service manages deploys of the Terra UI service to production. |
 | [Terra UI](https://github.com/DataBiosphere/terra-ui) | The Terra UI manages display of the terra website |

--- a/identity/What-We-Own.md
+++ b/identity/What-We-Own.md
@@ -8,5 +8,6 @@
 | [Calhoun](https://github.com/DataBiosphere/calhoun) | Calhoun is a service which generates read-only views of notebooks for previews. It does not require a running cluster, and spits out the notebook file as HTML. |
 | [Job Manager](https://github.com/DataBiosphere/job-manager) | Job manager is a UI and API service that is ued by users of the Terra platform to manage and inspect in progress, finished, or errored batch jobs. |
 | [Lyle](https://github.com/DataBiosphere/lyle) | Lyle is a service to manage allocating temporary google service accounts for use as test users |
+| [Rex](https://github.com/DataBiosphere/rex) | Rex is a service for collecting NPS survey responses. |
 | [Saturn UI Prod Deploy](https://github.com/DataBiosphere/saturn-ui-prod-deploy) | This service manages deploys of the Terra UI service to production. |
 | [Terra UI](https://github.com/DataBiosphere/terra-ui) | The Terra UI manages display of the terra website |

--- a/identity/What-We-Own.md
+++ b/identity/What-We-Own.md
@@ -1,0 +1,12 @@
+# What repositories we manage
+
+## Current owned services in alphabetical order
+| Name | Description |
+| ---- | ----------- |
+| [Bard](https://github.com/DataBiosphere/bard) | Bard is a service which manages our integrations with metrics services. As of 6/24/2020, this is only Mixpanel. |
+| [Bueller](https://github.com/DataBiosphere/terra-ui/blob/dev/integration-tests/Bueller.md) | Bueller is a service which hosts our integration tests for the Terra UI as an application, with one endpoint for each integration test. |
+| [Calhoun](https://github.com/DataBiosphere/calhoun) | Calhoun is a service which generates read-only views of notebooks for previews. It does not require a running cluster, and spits out the notebook file as markdown. |
+| [Job Manager](https://github.com/DataBiosphere/job-manager) | Job manager is a UI and API service that is ued by users of the Terra platform to manage and inspect in progress, finished, or errored batch jobs. |
+| [Lyle](https://github.com/DataBiosphere/lyle) | Lyle is a service to manage allocating temporary google service accounts for our test users |
+| [Saturn UI Prod Deploy](https://github.com/DataBiosphere/saturn-ui-prod-deploy) | This service manages deploys of the Terra UI service to production. |
+| [Terra UI](https://github.com/DataBiosphere/terra-ui) | The Terra UI manages display of the terra website |

--- a/identity/What-We-Own.md
+++ b/identity/What-We-Own.md
@@ -7,6 +7,6 @@
 | [Bueller](https://github.com/DataBiosphere/terra-ui/blob/dev/integration-tests/Bueller.md) | Bueller is a service which hosts our integration tests for the Terra UI as an application, with one endpoint for each integration test. |
 | [Calhoun](https://github.com/DataBiosphere/calhoun) | Calhoun is a service which generates read-only views of notebooks for previews. It does not require a running cluster, and spits out the notebook file as markdown. |
 | [Job Manager](https://github.com/DataBiosphere/job-manager) | Job manager is a UI and API service that is ued by users of the Terra platform to manage and inspect in progress, finished, or errored batch jobs. |
-| [Lyle](https://github.com/DataBiosphere/lyle) | Lyle is a service to manage allocating temporary google service accounts for our test users |
+| [Lyle](https://github.com/DataBiosphere/lyle) | Lyle is a service to manage allocating temporary google service accounts for use as test users |
 | [Saturn UI Prod Deploy](https://github.com/DataBiosphere/saturn-ui-prod-deploy) | This service manages deploys of the Terra UI service to production. |
 | [Terra UI](https://github.com/DataBiosphere/terra-ui) | The Terra UI manages display of the terra website |

--- a/identity/What-We-Own.md
+++ b/identity/What-We-Own.md
@@ -5,7 +5,7 @@
 | ---- | ----------- |
 | [Bard](https://github.com/DataBiosphere/bard) | Bard is a service which manages our integrations with metrics services. As of 6/24/2020, this is only Mixpanel. |
 | [Bueller](https://github.com/DataBiosphere/terra-ui/blob/dev/integration-tests/Bueller.md) | Bueller is a service which hosts our integration tests for the Terra UI as an application, with one endpoint for each integration test. |
-| [Calhoun](https://github.com/DataBiosphere/calhoun) | Calhoun is a service which generates read-only views of notebooks for previews. It does not require a running cluster, and spits out the notebook file as markdown. |
+| [Calhoun](https://github.com/DataBiosphere/calhoun) | Calhoun is a service which generates read-only views of notebooks for previews. It does not require a running cluster, and spits out the notebook file as HTML. |
 | [Job Manager](https://github.com/DataBiosphere/job-manager) | Job manager is a UI and API service that is ued by users of the Terra platform to manage and inspect in progress, finished, or errored batch jobs. |
 | [Lyle](https://github.com/DataBiosphere/lyle) | Lyle is a service to manage allocating temporary google service accounts for use as test users |
 | [Saturn UI Prod Deploy](https://github.com/DataBiosphere/saturn-ui-prod-deploy) | This service manages deploys of the Terra UI service to production. |


### PR DESCRIPTION
This adds the table of contents with short descriptions for each file, and a document for what services we own.