### PR TITLE
Add name origins [SATURN-1758]

### DIFF
--- a/identity/What-We-Own.md
+++ b/identity/What-We-Own.md
@@ -1,13 +1,13 @@
 # What repositories we manage
 
 ## Current owned services in alphabetical order
-| Name | Description |
-| ---- | ----------- |
-| [Bard](https://github.com/DataBiosphere/bard) | Bard is a service which manages our integrations with metrics services. As of 6/24/2020, this is only Mixpanel. |
-| [Bueller](https://github.com/DataBiosphere/terra-ui/blob/dev/integration-tests/Bueller.md) | Bueller is a service which hosts our integration tests for the Terra UI as an application, with one endpoint for each integration test. |
-| [Calhoun](https://github.com/DataBiosphere/calhoun) | Calhoun is a service which generates read-only views of notebooks for previews. It does not require a running cluster, and spits out the notebook file as HTML. |
-| [Job Manager](https://github.com/DataBiosphere/job-manager) | Job manager is a UI and API service that is ued by users of the Terra platform to manage and inspect in progress, finished, or errored batch jobs. |
-| [Lyle](https://github.com/DataBiosphere/lyle) | Lyle is a service to manage allocating temporary google service accounts for use as test users |
-| [Rex](https://github.com/DataBiosphere/rex) | Rex is a service for collecting Net Promoter Score (NPS) survey responses. |
-| [Saturn UI Prod Deploy](https://github.com/DataBiosphere/saturn-ui-prod-deploy) | This service manages deploys of the Terra UI service to production. |
-| [Terra UI](https://github.com/DataBiosphere/terra-ui) | The Terra UI manages display of the terra website |
+| Name | Description | Name Origin
+| ---- | ----------- | ----------- |
+| [Bard](https://github.com/DataBiosphere/bard) | Bard is a service which manages our integrations with metrics services. As of 6/24/2020, this is only Mixpanel. | Bard is a metric system → metric system uses meters → poets use meters → bards are poets → bards tell stories (kind of what we are doing)
+| [Bueller](https://github.com/DataBiosphere/terra-ui/blob/dev/integration-tests/Bueller.md) | Bueller is a service which hosts our integration tests for the Terra UI as an application, with one endpoint for each integration test. | Bueller calls on each test -> calling attendance -> roll call -> famous roll call scene -> “Bueller Bueller” (from Ferris Bueller’s day off) 
+| [Calhoun](https://github.com/DataBiosphere/calhoun) | Calhoun is a service which generates read-only views of notebooks for previews. It does not require a running cluster, and spits out the notebook file as HTML. | Calhoun is named for the character Noah Calhoun (Ryan Gosling) from the movie The Notebook
+| [Job Manager](https://github.com/DataBiosphere/job-manager) | Job manager is a UI and API service that is ued by users of the Terra platform to manage and inspect in progress, finished, or errored batch jobs. | Job Manager is named as it is the service a user can use to manage the jobs/workflows/WDLs/methods they are running
+| [Lyle](https://github.com/DataBiosphere/lyle) | Lyle is a service to manage allocating temporary google service accounts for use as test users | Lyle is named for the character Lyle from the book Lyle, Lyle, Crocodile because  ‘allocator’ service sounds like ‘alligator’ service
+| [Rex](https://github.com/DataBiosphere/rex) | Rex is a service for collecting Net Promoter Score (NPS) survey responses. | Rex is a play on ‘Recommend’; as in a user would recommend Terra in their survey response
+| [Saturn UI Prod Deploy](https://github.com/DataBiosphere/saturn-ui-prod-deploy) | This service manages deploys of the Terra UI service to production. | Terra was very very originally the Saturn V Research Environment, this team kept the name Saturn even after the app changed names.
+| [Terra UI](https://github.com/DataBiosphere/terra-ui) | The Terra UI manages display of the terra website | Terra is the name of the web application that Terra Workbench supports and Terra powered apps (such as ANVIL and BioDataCatalyst) utilize.


### PR DESCRIPTION
I think it is worthwhile to document why services are named as they are here. 

This org likes creative names and I think it can be confusing and alienating to not know the origin of why things are named as they are. Also knowing the name origin helps one remember what the service is about since many names are puns based on the functionality of the service.